### PR TITLE
Prevent shutdown on boot if x735 card is not present

### DIFF
--- a/x735-v25.sh
+++ b/x735-v25.sh
@@ -6,6 +6,15 @@
 
     echo '#!/bin/bash
 
+# Prevent killing the Pi if the X735 is not installed:
+installed=$(lsusb | grep "0862 ASMedia")
+
+if [ -z "$installed" ]
+then
+  echo "X735 not detected, aborting"
+  exit 0
+fi
+
 SHUTDOWN=5
 REBOOTPULSEMINIMUM=200
 REBOOTPULSEMAXIMUM=600


### PR DESCRIPTION
If this software is installed on a Raspberry Pi that has no x735, it will shutdown on boot, because /sys/class/gpio/gpio5/value will always be 1. This is very dangerous. With the proposed changes if the card is not detected the script will exit. Maybe you have a better command to detect if the card is present.