### PR TITLE
Remove dependencies to pigpiod

### DIFF
--- a/install-dietpi.sh
+++ b/install-dietpi.sh
@@ -94,15 +94,13 @@ if [ "$_IP" ]; then
 fi
 
 /etc/x-c1-pwr.sh &
-python ${CUR_DIR}/pwm_fan_control.py &
+python3 ${CUR_DIR}/pwm_fan_control.py &
 exit 0
 " > /etc/rc.local
 sudo chmod +x /etc/rc.local
-sudo systemctl enable pigpiod
 
 # manual run
-sudo pigpiod
-python ${CUR_DIR}/pwm_fan_control.py &
+python3 ${CUR_DIR}/pwm_fan_control.py &
 
 echo "The installation is complete."
 echo "Please run 'sudo reboot' to reboot the device."

--- a/install-mynode.sh
+++ b/install-mynode.sh
@@ -70,17 +70,14 @@ echo "0" > /sys/class/gpio/gpio$BUTTON/value
 ' > /usr/local/bin/x735softsd.sh
 
 sudo chmod +x /usr/local/bin/x735softsd.sh
-sudo systemctl enable pigpiod
 
 USER_RUN_FILE=/home/admin/.bashrc
 CUR_DIR=$(pwd)
 sudo echo "alias x735off='sudo x735softsd.sh'" >> ${USER_RUN_FILE}
-#sudo echo "python ${CUR_DIR}/pwm_fan_control.py&"  >> ${USER_RUN_FILE}
+#sudo echo "python3 ${CUR_DIR}/pwm_fan_control.py&"  >> ${USER_RUN_FILE}
 
-sudo sed -i "$ i sudo pigpiod" /etc/rc.local
-sudo sed -i "$ i python ${CUR_DIR}/pwm_fan_control.py&" /etc/rc.local
+sudo sed -i "$ i python3 ${CUR_DIR}/pwm_fan_control.py&" /etc/rc.local
 
-sudo pigpiod
 python ${CUR_DIR}/pwm_fan_control.py &
 
 echo "The installation is complete."

--- a/install.sh
+++ b/install.sh
@@ -69,15 +69,13 @@ echo "X735 Shutting down..."
 echo "0" > /sys/class/gpio/gpio$BUTTON/value
 ' > /usr/local/bin/x735softsd.sh
 sudo chmod +x /usr/local/bin/x735softsd.sh
-sudo systemctl enable pigpiod
 
 USER_RUN_FILE=/home/pi/.bashrc
 CUR_DIR=$(pwd)
 sudo echo "alias x735off='sudo x735softsd.sh'" >> ${USER_RUN_FILE}
-sudo echo "python ${CUR_DIR}/pwm_fan_control.py&"  >> ${USER_RUN_FILE}
+sudo echo "python3 ${CUR_DIR}/pwm_fan_control.py&"  >> ${USER_RUN_FILE}
 
-sudo pigpiod
-python ${CUR_DIR}/pwm_fan_control.py &
+python3 ${CUR_DIR}/pwm_fan_control.py &
 
 echo "The installation is complete."
 echo "Please run 'sudo reboot' to reboot the device."

--- a/install_service.sh
+++ b/install_service.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+# Author: Tranko (https://github.com/thorkseng/x
+# Create a small service that start when the pi stars.
+# This avoid to have it in bashrc and wait until the user logon.
+# This avoid the issue that if you logon several times ir runned several times.
+
+# Create the service
+echo "Creating the service in /etc/systemd/system/ with name x735fan.service"
+sudo cat > /etc/systemd/system/x735fan.service <<EOF
+[Unit]
+Description=x735 Fan Service
+After=multi-user.target
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/bin/python3 $HOME/x735-v2.5/pwm_fan_control.py
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Reload the daemon
+echo "Reload the systemd daemon"
+sudo systemctl daemon-reload
+
+# Enable the service to be enabled on startup
+echo "Enable the new service (it will start in any reboot of the system)."
+sudo systemctl enable x735fan.service
+
+# Start the service
+echo "Start the service"
+sudo systemctl start x735fan.service
+
+# Check that the service is running fine
+# sudo systemctl status x735fan.service | grep "started"
+STATUS="$(systemctl is-active x735fan.service)"
+if [ "${STATUS}" = "active" ]; then
+    echo "Service is active and running correctly"
+else
+    echo "Service not running something was wrong."
+    exit 1
+fi
+
+# If everything goes fine, remove the included py script in .bashrc
+# Delete local .bashrc lines that are not longer needed to start the fan
+echo "Detelete the execution of pwm_fan_control from the file .bashrc"
+sed -i '/pwm_fan_control.py/d' $HOME/.bashrc
+
+# Additional notes
+echo "Everything going fine"
+echo "Now the fan will start in any reboot of the system\n"
+echo "You can control the service with the next commands:"
+echo "Check the status of the service: sudo systemctl status x735fan.service"
+echo "Stop the service: sudo systemctl stop x735fan.service"
+echo "Restart the service: sudo systemctl restart x735fan.service"
+echo "Check the logs of the service: journalctl -u x735fan.service"
+echo "Edit the service configuration in: /etc/systemd/system/x735fan.service"
+

--- a/pwm_fan_control.py
+++ b/pwm_fan_control.py
@@ -1,35 +1,39 @@
-#!/usr/bin/python
-import pigpio
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
 import time
+import RPi.GPIO as GPIO
 
-servo = 13
+# configuration
+fan_pin = 13
+temp_pwm_curve = [ (30,30), (50,50), (55,75), (60,90), (80,100) ]
+fan_threshold_temp = 30
 
-pwm = pigpio.pi()
-pwm.set_mode(servo, pigpio.OUTPUT)
-pwm.set_PWM_frequency( servo, 25000 )
-pwm.set_PWM_range(servo, 100)
-while(1):
-     #get CPU temp
-     file = open("/sys/class/thermal/thermal_zone0/temp")
-     temp = float(file.read()) / 1000.00
-     temp = float('%.2f' % temp)
-     file.close()
+# initialization
+GPIO.setmode(GPIO.BCM)
+GPIO.setwarnings(False)
+GPIO.setup(fan_pin, GPIO.OUT)
+pwm = GPIO.PWM(fan_pin, 25000)
+pwm.start(0)
 
-     if(temp > 30):
-          pwm.set_PWM_dutycycle(servo, 40)
+# control loop
+try:
+     while(1):
+          #get CPU temp
+          file = open("/sys/class/thermal/thermal_zone0/temp")
+          temp = float(file.read()) / 1000.00
+          temp = float('%.2f' % temp)
+          file.close()
 
-     if(temp > 50):
-          pwm.set_PWM_dutycycle(servo, 50)
+          if(temp < fan_threshold_temp):
+               pwm.ChangeDutyCycle(0)
+          else:
+               for item in temp_pwm_curve:
+                    if(temp > item[0]):
+                         pwm.ChangeDutyCycle(item[1])
 
-     if(temp > 55):
-          pwm.set_PWM_dutycycle(servo, 75)
+          time.sleep(1)
 
-     if(temp > 60):
-          pwm.set_PWM_dutycycle(servo, 90)
-
-     if(temp > 65):
-          pwm.set_PWM_dutycycle(servo, 100)
-
-     if(temp < 30):
-          pwm.set_PWM_dutycycle(servo, 0)
-     time.sleep(1)
+except:
+    pwm.stop()
+    GPIO.cleanup()

--- a/read_fan_speed.py
+++ b/read_fan_speed.py
@@ -30,7 +30,7 @@ GPIO.add_event_detect(TACH, GPIO.FALLING, fell)
 
 try:
     while True:
-        print "%.f RPM" % rpm
+        print ("%.f RPM" % rpm)
         rpm = 0
         time.sleep(1)
 


### PR DESCRIPTION
To decrease depenendies on external library I replaced pigpiod with RPi.GPIO as used already in read_fan_speed.py. 

in detail this PR contains:
- remove dependency to pigpiod
- refactor pwm_fan_control.py
- proper use of python3 for pwm_fan_control.py in all install scripts
additionally: fix py3 issue with read_fan_speed.py