### PR TITLE
Fix delete of pwm_fan_control.py command from .bashrc in install_service.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# x735-v2.5 for Debian Bullseye / Debian 11
+# x735-v2.5 for Python3 + Debian Bullseye / Debian 11
 
 ## Installation
 This scripts are tested on RaspiaOS 64 bits upgraded to Debian Bullseye.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ This packages are upgrade to use Python3 (Python2 is deprecated):
     sudo bash install.sh
     sudo reboot
 
+## Usage
+For activate the fan manually you can do with the next command, also, this command is added (in background) in the .bashrc of the profile of the user:
+
+    python3 pwm_fan_control.py
+
+For read the speed of the system you need to use python3 instead python
+
+    python3 read_fan_speed.py 
+
 ## Credits
 Based on the [GeekWorm user guide](https://wiki.geekworm.com/X735_V2.5_Software) and the original [repository of GeekWorm.com](https://github.com/geekworm-com/x735-v2.5)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 This scripts are tested on RaspiaOS 64 bits upgraded to Debian Bullseye.
-You should use the next guide (based on the official website https://wiki.geekworm.com/X735_V2.5_Software).
+You should use the next guide (based on the [official website of the GeekWorm X735](https://wiki.geekworm.com/X735_V2.5_Software).
 This packages are upgrade to use Python3 (Python2 is deprecated):
 
     sudo apt install python3 python3-smbus python3-pigpio

--- a/README.md
+++ b/README.md
@@ -1,4 +1,20 @@
-# x735-v2.5
-This is the safe shutdown script and some python sample code.
+# x735-v2.5 for Debian Bullseye / Debian 11
 
-User guide: https://wiki.geekworm.com/X735_V2.5_Software
+## Installation
+This scripts are tested on RaspiaOS 64 bits upgraded to Debian Bullseye.
+You should use the next guide (based on the official website https://wiki.geekworm.com/X735_V2.5_Software).
+This packages are upgrade to use Python3 (Python2 is deprecated):
+
+    sudo apt install python3 python3-smbus python3-pigpio
+    sudo apt install pigpio
+    sudo apt install git
+    git clone https://github.com/thorkseng/x735-v2.5/
+    cd x735-v2.5
+    sudo chmod +x *.sh
+    sudo bash install.sh
+    sudo reboot
+
+## Credits
+Based on the [GeekWorm user guide](https://wiki.geekworm.com/X735_V2.5_Software) and the original [repository of GeekWorm.com](https://github.com/geekworm-com/x735-v2.5)
+
+Feel free to copy and modify :)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ This packages are upgrade to use Python3 (Python2 is deprecated):
     sudo bash install.sh
     sudo reboot
 
+## Installation of service:
+The shell script "install_service.sh" will create a new service in the folder /etc/systemd/system/ with the name x735fan.service.
+Will enable and activate it and check that it is running. In that case will remove from .bashrch the execution of the .py file.
+The only need to do it it's execute the script:
+
+    bash install_service.sh
+
 ## Usage
 For activate the fan manually you can do with the next command, also, this command is added (in background) in the .bashrc of the profile of the user:
 

--- a/install-dietpi.sh
+++ b/install-dietpi.sh
@@ -94,7 +94,7 @@ if [ "$_IP" ]; then
 fi
 
 /etc/x-c1-pwr.sh &
-python ${CUR_DIR}/pwm_fan_control.py &
+python3 ${CUR_DIR}/pwm_fan_control.py &
 exit 0
 " > /etc/rc.local
 sudo chmod +x /etc/rc.local
@@ -102,7 +102,7 @@ sudo systemctl enable pigpiod
 
 # manual run
 sudo pigpiod
-python ${CUR_DIR}/pwm_fan_control.py &
+python3 ${CUR_DIR}/pwm_fan_control.py &
 
 echo "The installation is complete."
 echo "Please run 'sudo reboot' to reboot the device."

--- a/install.sh
+++ b/install.sh
@@ -74,10 +74,10 @@ sudo systemctl enable pigpiod
 USER_RUN_FILE=/home/pi/.bashrc
 CUR_DIR=$(pwd)
 sudo echo "alias x735off='sudo x735softsd.sh'" >> ${USER_RUN_FILE}
-sudo echo "python ${CUR_DIR}/pwm_fan_control.py&"  >> ${USER_RUN_FILE}
+sudo echo "python3 ${CUR_DIR}/pwm_fan_control.py&"  >> ${USER_RUN_FILE}
 
 sudo pigpiod
-python ${CUR_DIR}/pwm_fan_control.py &
+python3 ${CUR_DIR}/pwm_fan_control.py &
 
 echo "The installation is complete."
 echo "Please run 'sudo reboot' to reboot the device."

--- a/install_service.sh
+++ b/install_service.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+# Author: Tranko (https://github.com/thorkseng/x
+# Create a small service that start when the pi stars.
+# This avoid to have it in bashrc and wait until the user logon.
+# This avoid the issue that if you logon several times ir runned several times.
+
+# Create the service
+echo "Creating the service in /etc/systemd/system/ with name x735fan.service"
+sudo cat > /etc/systemd/system/x735fan.service <<EOF
+[Unit]
+Description=x735 Fan Service
+After=multi-user.target
+
+[Service]
+Type=simple
+Restart=always
+ExecStart=/usr/bin/python3 $HOME/x735-v2.5/pwm_fan_control.py
+
+[Install]
+WantedBy=multi-user.target
+EOF
+
+# Reload the daemon
+echo "Reload the systemd daemon"
+sudo systemctl daemon-reload
+
+# Enable the service to be enabled on startup
+echo "Enable the new service (it will start in any reboot of the system)."
+sudo systemctl enable x735fan.service
+
+# Start the service
+echo "Start the service"
+sudo systemctl start x735fan.service
+
+# Check that the service is running fine
+# sudo systemctl status x735fan.service | grep "started"
+STATUS="$(systemctl is-active x735fan.service)"
+if [ "${STATUS}" = "active" ]; then
+    echo "Service is active and running correctly"
+else
+    echo "Service not running something was wrong."
+    exit 1
+fi
+
+# If everything goes fine, remove the included py script in .bashrc
+# Delete local .bashrc lines that are not longer needed to start the fan
+echo "Detelete the execution of pwm_fan_control from the file .bashrc"
+sed -i '/pwm_fan_control.py/d' $HOME/.bashrc
+
+# Additional notes
+echo "Everything going fine"
+echo "Now the fan will start in any reboot of the system\n"
+echo "You can control the service with the next commands:"
+echo "Check the status of the service: sudo systemctl status x735fan.service"
+echo "Stop the service: sudo systemctl stop x735fan.service"
+echo "Restart the service: sudo systemctl restart x735fan.service"
+echo "Check the logs of the service: journalctl -u x735fan.service"
+echo "Edit the service configuration in: /etc/systemd/system/x735fan.service"

--- a/install_service.sh
+++ b/install_service.sh
@@ -6,6 +6,7 @@
 # This avoid the issue that if you logon several times ir runned several times.
 
 # Create the service
+CUR_DIR=$(pwd)
 echo "Creating the service in /etc/systemd/system/ with name x735fan.service"
 sudo cat > /etc/systemd/system/x735fan.service <<EOF
 [Unit]
@@ -15,7 +16,7 @@ After=multi-user.target
 [Service]
 Type=simple
 Restart=always
-ExecStart=/usr/bin/python3 $HOME/x735-v2.5/pwm_fan_control.py
+ExecStart=/usr/bin/python3 ${CUR_DIR}/pwm_fan_control.py
 
 [Install]
 WantedBy=multi-user.target

--- a/read_fan_speed.py
+++ b/read_fan_speed.py
@@ -30,7 +30,7 @@ GPIO.add_event_detect(TACH, GPIO.FALLING, fell)
 
 try:
     while True:
-        print "%.f RPM" % rpm
+        print("%.f RPM" % rpm)
         rpm = 0
         time.sleep(1)
 


### PR DESCRIPTION
install_service.sh should be executed with sudo otherwise it fails.

In addition, if executed with sudo the variable $HOME will be evaluated with "/root" so the line with "pwm_fan_control.py" will not be found in .bashrc so we should use another variable evaluated tu the user's home that execute sudo:

```
USER_HOME=$(getent passwd $SUDO_USER | cut -d: -f6)
sed -i '/pwm_fan_control.py/d' $USER_HOME/.bashrc
```